### PR TITLE
Update Checker.java

### DIFF
--- a/src/main/java/pl/touk/throwing/Checker.java
+++ b/src/main/java/pl/touk/throwing/Checker.java
@@ -9,7 +9,7 @@ public final class Checker {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T, E extends Throwable> T checked(Class exceptionType, Supplier<T> supplier) throws E {
+    public static <T, E extends Throwable> T checked(Class<E> exceptionType, Supplier<T> supplier) throws E {
         try {
             return supplier.get();
         } catch (WrappedException ex) {


### PR DESCRIPTION
With this change, the compiler will enforce catching of the checked exception. Without it, I find that it does not enforce this.